### PR TITLE
Fix validity check in invoker activation

### DIFF
--- a/invoker.js
+++ b/invoker.js
@@ -321,12 +321,11 @@ export function apply() {
 
     if (source.form && source.getAttribute("type") !== "button") {
       event.preventDefault();
-
-       throw new Error(
-         "Element with `commandFor` is a form participant. " +
-           "It should explicitly set `type=button` in order for `commandFor` to work. " +
-           "In order for it to act as a Submit button, it must not have command or commandfor attributes",
-       );
+      throw new Error(
+        "Element with `commandFor` is a form participant. " +
+          "It should explicitly set `type=button` in order for `commandFor` to work. " +
+          "In order for it to act as a Submit button, it must not have command or commandfor attributes",
+      );
     }
 
     if (source.hasAttribute("command") !== source.hasAttribute("commandfor")) {

--- a/invoker.js
+++ b/invoker.js
@@ -319,15 +319,6 @@ export function apply() {
     const source = event.target.closest("button[commandfor], button[command]");
     if (!source) return;
 
-    if (this.form && this.getAttribute("type") !== "button") {
-      event.preventDefault();
-      throw new Error(
-        "Element with `commandFor` is a form participant. " +
-          "It should explicitly set `type=button` in order for `commandFor` to work. " +
-          "In order for it to act as a Submit button, it must not have command or commandfor attributes",
-      );
-    }
-
     if (source.hasAttribute("command") !== source.hasAttribute("commandfor")) {
       const attr = source.hasAttribute("command") ? "command" : "commandfor";
       const missing = source.hasAttribute("command") ? "commandfor" : "command";

--- a/invoker.js
+++ b/invoker.js
@@ -319,6 +319,16 @@ export function apply() {
     const source = event.target.closest("button[commandfor], button[command]");
     if (!source) return;
 
+    if (source.form && source.getAttribute("type") !== "button") {
+      event.preventDefault();
+
+       throw new Error(
+         "Element with `commandFor` is a form participant. " +
+           "It should explicitly set `type=button` in order for `commandFor` to work. " +
+           "In order for it to act as a Submit button, it must not have command or commandfor attributes",
+       );
+    }
+
     if (source.hasAttribute("command") !== source.hasAttribute("commandfor")) {
       const attr = source.hasAttribute("command") ? "command" : "commandfor";
       const missing = source.hasAttribute("command") ? "commandfor" : "command";


### PR DESCRIPTION
This change updates `handleInvokerActivation` so that the `source` button is checked for validity, rather than `this` (which is the `ShadowRoot` or `Document`).

~This change removes a block of code from `handleInvokerActivation` that expects `this.form`. However, `this` would never have a `form` property. The `handleInvokerActivation(event)` listener gets `this` from `setupInvokeListeners(target)`, which only sets it to `ShadowRoot` and `Document` objects.~