### PR TITLE
Add typing support for empty command string

### DIFF
--- a/invoker.d.ts
+++ b/invoker.d.ts
@@ -7,7 +7,7 @@ declare global {
   }
   interface HTMLButtonElement {
     commandForElement: HTMLElement | null;
-    command: 'show-modal' | 'close' | 'hide-popover' | 'toggle-popover' | 'show-popover' | `--${string}`;
+    command: '' | 'show-modal' | 'close' | 'hide-popover' | 'toggle-popover' | 'show-popover' | `--${string}`;
   }
   interface Window {
     CommandEvent: CommandEvent;


### PR DESCRIPTION
This changes the typing for `command` to support `""`, which should be valid according to the following implementation references in `invoker.js`:
- `new CommandEvent` [[1]](https://github.com/keithamus/invokers-polyfill/blob/v0.5.2/invoker.js#L71-L74)
- `HTMLButtonElement.command` [[1]](https://github.com/keithamus/invokers-polyfill/blob/v0.5.2/invoker.js#L206) [[2]](https://github.com/keithamus/invokers-polyfill/blob/v0.5.2/invoker.js#L217)