### PR TITLE
Assign Event classes to globalThis

### DIFF
--- a/invoker.js
+++ b/invoker.js
@@ -416,14 +416,5 @@ export function apply() {
 
   setupInvokeListeners(document);
 
-  Object.defineProperty(window, "CommandEvent", {
-    value: CommandEvent,
-    configurable: true,
-    writable: true,
-  });
-  Object.defineProperty(window, "InvokeEvent", {
-    value: InvokeEvent,
-    configurable: true,
-    writable: true,
-  });
+  Object.assign(globalThis, { CommandEvent, InvokeEvent });
 }


### PR DESCRIPTION
This change assigns `CommandEvent` and `InvokeEvent` to `globalThis`, which is where the implementation expects to check it [[1]](https://github.com/keithamus/invokers-polyfill/blob/v0.5.2/invoker.js#L6) [[2]](https://github.com/keithamus/invokers-polyfill/blob/v0.5.2/invoker.js#L12), and also where all other global object lookups occur [[1]](https://github.com/keithamus/invokers-polyfill/blob/v0.5.2/invoker.js#L58) [[2]](https://github.com/keithamus/invokers-polyfill/blob/v0.5.2/invoker.js#L409) [[3]](https://github.com/keithamus/invokers-polyfill/blob/v0.5.2/invoker.js#L411).