### PR TITLE
Consistently presume DOM classes

### DIFF
--- a/invoker.js
+++ b/invoker.js
@@ -55,8 +55,6 @@ export function apply() {
     return node;
   }
 
-  const ShadowRoot = globalThis.ShadowRoot || function () {};
-
   const commandEventSourceElements = new WeakMap();
   const commandEventActions = new WeakMap();
 
@@ -406,9 +404,9 @@ export function apply() {
     };
   }
 
-  applyInvokerMixin(globalThis.HTMLButtonElement || function () {});
+  applyInvokerMixin(HTMLButtonElement);
 
-  observeShadowRoots(globalThis.HTMLElement || function () {}, (shadow) => {
+  observeShadowRoots(HTMLElement, (shadow) => {
     setupInvokeListeners(shadow);
     oncommandObserver.observe(shadow, { attributeFilter: ["oncommand"] });
     applyOnCommandHandler(shadow.querySelectorAll("[oncommand]"));


### PR DESCRIPTION
This change presumes `HTMLElement` exists (and `HTMLButtonElement`, by extension), as the implementation already presumes it exists [[1]](https://github.com/keithamus/invokers-polyfill/blob/v0.5.2/invoker.js#L257).

This change presumes `ShadowRoot` exists, as the implementation already implicitly presumes it exists [[1]](https://github.com/keithamus/invokers-polyfill/blob/v0.5.2/invoker.js#L395).