### PR TITLE
Add `package.json` fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "invokers-polyfill",
   "version": "0.0.0-development",
   "description": "This polyfills the HTML `invoketarget`/`invokeaction`, as proposed by the Open UI group.",
+  "homepage": "https://github.com/keithamus/invokers-polyfill#readme",
+  "bugs": {
+    "url": "https://github.com/keithamus/invokers-polyfill/issues"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/keithamus/invokers-polyfill.git"


### PR DESCRIPTION
This is a useful thing to add for anyone who has this installed as a dev dependency, they'll be able to hover over it in their IDE to see a link to the GitHub page so they can easily click through and check the docs etc. It'll also display on the npmjs package page.