### PR TITLE
Remove PURE annotations

### DIFF
--- a/invoker.js
+++ b/invoker.js
@@ -1,4 +1,3 @@
-/*#__PURE__*/
 export function isSupported() {
   return (
     typeof HTMLButtonElement !== "undefined" &&
@@ -7,7 +6,6 @@ export function isSupported() {
   );
 }
 
-/*#__PURE__*/
 export function isPolyfilled() {
   return !/native code/i.test((globalThis.CommandEvent || {}).toString());
 }


### PR DESCRIPTION
It looks like these annotations are not necessary for modern bundlers to perform tree-shaking. And in fact, they cause Rollup to issue warnings (see #66).

I tested Rollup, Webpacker and esBuild. They all successfully tree-shake these functions even without annotations.

Closes #66 